### PR TITLE
Update Docker-Compose example to use host networking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,25 +34,25 @@ perara/wireguard-manager
 
 ## Docker-compose
 ```yaml
-  version: "2"
-  services:
-   wireguard:
-     container_name: wireguard-manager
-     image: perara/wireguard-manager
-     cap_add:
-       - NET_ADMIN
-     ports:
-        - 51800:51900/udp
-        - 8888:8888
-     volumes:
-       - ./ops/wireguard/_data:/config
-     environment:
-       HOST: 0.0.0.0
-       PORT: 8888
-       ADMIN_PASSWORD: admin
-       ADMIN_USERNAME: admin
-       WEB_CONCURRENCY: 1
-     network_mode: host
+version: "2"
+services:
+ wireguard:
+    container_name: wireguard-manager
+    image: perara/wireguard-manager
+    cap_add:
+      - NET_ADMIN
+    ports:
+       - 51800:51900/udp
+       - 8888:8888
+    volumes:
+      - ./ops/wireguard/_data:/config
+    environment:
+      HOST: 0.0.0.0
+      PORT: 8888
+      ADMIN_PASSWORD: admin
+      ADMIN_USERNAME: admin
+      WEB_CONCURRENCY: 1
+    network_mode: host
 ```
 
 # Install (OS)

--- a/README.md
+++ b/README.md
@@ -34,22 +34,25 @@ perara/wireguard-manager
 
 ## Docker-compose
 ```yaml
-  wireguard:
-    container_name: wireguard-manager
-    image: perara/wireguard-manager
-    cap_add:
-      - NET_ADMIN
-    ports:
-       - 51800:51900/udp
-       - 8888:8888
-    volumes:
-      - ./ops/wireguard/_data:/config
-    environment:
-      HOST: 0.0.0.0
-      PORT: 8888
-      ADMIN_PASSWORD: admin
-      ADMIN_USERNAME: admin
-      WEB_CONCURRENCY: 1
+  version: "2"
+  services:
+   wireguard:
+     container_name: wireguard-manager
+     image: perara/wireguard-manager
+     cap_add:
+       - NET_ADMIN
+     ports:
+        - 51800:51900/udp
+        - 8888:8888
+     volumes:
+       - ./ops/wireguard/_data:/config
+     environment:
+       HOST: 0.0.0.0
+       PORT: 8888
+       ADMIN_PASSWORD: admin
+       ADMIN_USERNAME: admin
+       WEB_CONCURRENCY: 1
+     network_mode: host
 ```
 
 # Install (OS)


### PR DESCRIPTION
Update the docker-compose example in the readme to use host network, without this wireguard wasn't getting configured, at least on the Ubuntu 18.04 VM I was testing on.

