### PR TITLE
Adding autostart of wireguard server

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,17 @@ When docker container/server has started, go to http://localhost:8888
 
 
 # Environment variables
-| Environment      | Description                                                              | Recommended |
-|------------------|--------------------------------------------------------------------------|-------------|
-| GUNICORN_CONF    | Location of custom gunicorn configuration                                | default     |
-| WORKERS_PER_CORE | How many concurrent workers should there be per available core (Gunicorn | default     |
-| WEB_CONCURRENCY  | The number of worker processes for handling requests. (Gunicorn)         | 1           |
-| HOST             | 0.0.0.0 or unix:/tmp/gunicorn.sock if reverse proxy. Remember to mount   | 0.0.0.0     |
-| PORT             | The port to use if running with IP host bind                             | 80          |
-| LOG_LEVEL        | Logging level of gunicorn/python                                         | info        |
-| ADMIN_USERNAME   | Default admin username on database creation                              | admin       |
-| ADMIN_PASSWORD   | Default admin password on database creation                              | admin       |
+| Environment         | Description                                                               | Recommended |
+|---------------------|---------------------------------------------------------------------------|-------------|
+| GUNICORN_CONF       | Location of custom gunicorn configuration                                 | default     |
+| WORKERS_PER_CORE    | How many concurrent workers should there be per available core (Gunicorn) | default     |
+| WEB_CONCURRENCY     | The number of worker processes for handling requests. (Gunicorn)          | 1           |
+| HOST                | 0.0.0.0 or unix:/tmp/gunicorn.sock if reverse proxy. Remember to mount    | 0.0.0.0     |
+| PORT                | The port to use if running with IP host bind                              | 80          |
+| LOG_LEVEL           | Logging level of gunicorn/python                                          | info        |
+| ADMIN_USERNAME      | Default admin username on database creation                               | admin       |
+| ADMIN_PASSWORD      | Default admin password on database creation                               | admin       |
+| AUTOSTART_INTERFACE | A comma-separated list of interfaces to automatically start.              | wg0,wg1,wg2 |
 
 # Showcase
 ![Illustration](docs/images/0.png)

--- a/docker/start.py
+++ b/docker/start.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from os.path import isdir
 DEFAULT_MODULE_LOCATIONS = [("app.main", "/app/app/main.py"), ("main", "/app/main.py")]
 DEFAULT_GUNICORN_CONF = [(None, "/app/gunicorn_config.py"), (None, "/app/startup/gunicorn_config.py")]
@@ -29,4 +30,5 @@ if __name__ == "__main__":
     os.putenv("APP_MODULE", APP_MODULE)
     os.putenv("GUNICORN_CONF", GUNICORN_CONF)
 
+    subprocess.call(["python3", "autostart.py"])
     os.system(f"gunicorn -k uvicorn.workers.UvicornWorker -c {GUNICORN_CONF} {APP_MODULE}")

--- a/wg_dashboard_backend/autostart.py
+++ b/wg_dashboard_backend/autostart.py
@@ -1,0 +1,33 @@
+import os
+import string
+from database import SessionLocal
+from sqlalchemy.orm import Session
+
+import models
+import script.wireguard
+
+# Quit if there isn't any interface specified for autostart
+if "AUTOSTART_INTERFACES" not in os.environ or not os.environ.get("AUTOSTART_INTERFACES"):
+    quit()
+
+interfaces = os.environ.get("AUTOSTART_INTERFACES").split(",")
+_db: Session = SessionLocal()
+
+for i in interfaces:
+    try:
+        i = i.strip()
+        server = _db.query(models.WGServer).filter(models.WGServer.interface == i).first()
+        if not server:
+            raise Exception('Could not find the interface ' + i)
+
+        last_state = server.is_running
+        if script.wireguard.is_installed() and last_state and not script.wireguard.is_running(server):
+            script.wireguard.start_interface(server)
+            print('Automatically started the interface ' + i)
+        elif last_state:
+            print('The interface ' + i + ' is already started')
+
+    except Exception as e:
+        print(e)
+
+_db.close()


### PR DESCRIPTION
Fixes #13 

Adding the option to automatically start the wireguard server when the
docker container starts. It's possible to control which wireguard
interface to actually start by specifying the environment variable
AUTOSTART_INTERFACES with a comma-separated list of interfaces.

Also fixed a forgotten end-parentheses in the README table.