### PR TITLE
Running state bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ The features of wg-manager includes:
   wireguard:
     container_name: wg-manager
     image: perara/wg-manager
+    restart: always
     cap_add:
       - NET_ADMIN
     #network_mode: host # Alternatively
     ports:
-       - 51800:51900/udp
+       - 51800-51900:51800-51900/udp
        - 8888:8888
     volumes:
       - ./wg-manager:/config
@@ -62,16 +63,16 @@ When docker container/server has started, go to http://localhost:8888
 
 
 # Environment variables
-| Environment      | Description                                                              | Recommended |
-|------------------|--------------------------------------------------------------------------|-------------|
-| GUNICORN_CONF    | Location of custom gunicorn configuration                                | default     |
-| WORKERS_PER_CORE | How many concurrent workers should there be per available core (Gunicorn | default     |
-| WEB_CONCURRENCY  | The number of worker processes for handling requests. (Gunicorn)         | 1           |
-| HOST             | 0.0.0.0 or unix:/tmp/gunicorn.sock if reverse proxy. Remember to mount   | 0.0.0.0     |
-| PORT             | The port to use if running with IP host bind                             | 80          |
-| LOG_LEVEL        | Logging level of gunicorn/python                                         | info        |
-| ADMIN_USERNAME   | Default admin username on database creation                              | admin       |
-| ADMIN_PASSWORD   | Default admin password on database creation                              | admin       |
+| Environment      | Description                                                               | Recommended |
+|------------------|---------------------------------------------------------------------------|-------------|
+| GUNICORN_CONF    | Location of custom gunicorn configuration                                 | default     |
+| WORKERS_PER_CORE | How many concurrent workers should there be per available core (Gunicorn) | default     |
+| WEB_CONCURRENCY  | The number of worker processes for handling requests. (Gunicorn)          | 1           |
+| HOST             | 0.0.0.0 or unix:/tmp/gunicorn.sock if reverse proxy. Remember to mount    | 0.0.0.0     |
+| PORT             | The port to use if running with IP host bind                              | 80          |
+| LOG_LEVEL        | Logging level of gunicorn/python                                          | info        |
+| ADMIN_USERNAME   | Default admin username on database creation                               | admin       |
+| ADMIN_PASSWORD   | Default admin password on database creation                               | admin       |
 
 # Showcase
 ![Illustration](docs/images/0.png)

--- a/wg_dashboard_backend/routers/v1/server.py
+++ b/wg_dashboard_backend/routers/v1/server.py
@@ -73,12 +73,14 @@ def add_interface(
 
 
 @router.post("/stop", response_model=schemas.WGServer)
-def start_server(
-        form_data: schemas.WGServer
+def stop_server(
+        server: schemas.WGServer,
+        sess: Session = Depends(middleware.get_db)
 ):
-    script.wireguard.stop_interface(form_data)
-    form_data.is_running = script.wireguard.is_running(form_data)
-    return form_data
+    script.wireguard.stop_interface(server)
+    server.is_running = script.wireguard.is_running(server)
+    server.sync(sess)
+    return server
 
 
 @router.post("/start", response_model=schemas.WGServer)

--- a/wg_dashboard_backend/script/wireguard.py
+++ b/wg_dashboard_backend/script/wireguard.py
@@ -108,7 +108,7 @@ def restart_interface(server: schemas.WGServer):
 def is_running(server: schemas.WGServer):
     try:
         output = _run_wg(server, ["show", server.interface])
-        if output is None:
+        if output is None or b'Unable to access interface: No such device' in output:
             return False
     except Exception as e:
         if b'No such device' in e.output:


### PR DESCRIPTION
Fix #13 

I found a few bugs when updating the running state, which resulted in the autostart feature didn't work as it was supposed to.

For some reason, the command 'wg show <interface>' doesn't return an error in the subprocess but it returns an output when the main.py first starts. That's the reason why the interfaces never started on boot, even if the last_state (is_running attribute) was set to True.

The code always though it already was running, since the _script.wireguard.is_running(s)_ function returned an incorrect state (True, in this case).

While I was looking into this, I also found that the is_running state never was set top False once an interface was started. And it turned out to be some "[copypasta](https://en.wiktionary.org/wiki/copypasta)" error.

So, after fixing these two issues, the state is now correct. Each interface will now keep its state, even if the docker container (or the application) is restarted.

I also fixed a few things in the README.md as well :)