### PR TITLE
DNS parameter removed when not entered

### DIFF
--- a/wg_dashboard_backend/templates/peer.j2
+++ b/wg_dashboard_backend/templates/peer.j2
@@ -1,7 +1,9 @@
 [Interface]
 Address = {{ data.peer.address }}/{{ data.server.subnet }}{%- if is_ipv6 -%},{{ data.peer.v6_address }}/{{ data.server.v6_subnet }}{%- endif %}
 PrivateKey = {{ data.peer.private_key }}
+{% if data.peer.dns %}
 DNS = {{ data.peer.dns }}
+{% endif %}
 
 [Peer]
 PublicKey = {{ data.server.public_key }}


### PR DESCRIPTION
Having the DNS parameter blank (e.g. "DNS = ") will cause import errors in the Android app using the QR Code. I've added an if statement that checks if the DNS field has been populated. If so then it will write out the whole "DNS = x.x.x.x". If not then it will not be included at all.