### PR TITLE
Fix for being able to disable IPv6 support

### DIFF
--- a/wg_dashboard_backend/migrations/versions/006_create_v6_subnet.py
+++ b/wg_dashboard_backend/migrations/versions/006_create_v6_subnet.py
@@ -6,7 +6,7 @@ def upgrade(migrate_engine):
     try:
         meta = MetaData(bind=migrate_engine)
         peer = Table('server', meta, autoload=True)
-        v6_subnet = Column('v6_subnet', INTEGER)
+        v6_subnet = Column('v6_subnet', INTEGER, nullable=True)
         v6_subnet.create(peer)
     except:
         pass


### PR DESCRIPTION
I was getting an error when trying to disable IPv6 support because the DB wasn't allowing the subnet to be null however the address was able to be null. Should be good now.