### PR TITLE
Set sqlalchemy version to less than 1.4.0

### DIFF
--- a/wg_dashboard_backend/requirements.txt
+++ b/wg_dashboard_backend/requirements.txt
@@ -2,7 +2,7 @@ pydantic
 fastapi
 aiofiles
 aiosqlite
-sqlalchemy
+sqlalchemy < 1.4.0
 databases
 PyJWT
 passlib


### PR DESCRIPTION
See https://github.com/perara/wg-manager/pull/91 for the reason to set the sqlalchemy to less than 1.4.0
`https://stackoverflow.com/questions/66644975/importerror-cannot-import-name-columnentity-from-sqlalchemy-orm-query`
[Traceback for issue - and outcome of fix.txt](https://github.com/perara/wg-manager/files/6176480/Traceback.for.issue.-.and.outcome.of.fix.txt)
