### PR TITLE
Clarify import error when no server files are found

### DIFF
--- a/wg_dashboard_frontend/src/app/page/dashboard/add-server/add-server.component.ts
+++ b/wg_dashboard_frontend/src/app/page/dashboard/add-server/add-server.component.ts
@@ -147,7 +147,11 @@ export class AddServerComponent implements OnInit {
     forkJoin(observables).subscribe(data => {
       let server: any = data.filter((x: any) => !x.isClient);
 
-      if(server.length !== 1) {
+      if(server.length == 0) {
+        this.notify.notify("error", "No server files detected!")
+        return false;
+      }
+      if(server.length > 1) {
         // TODO output error - should only be one server
         this.notify.notify("error", "Detected multiple server files!")
         return false;


### PR DESCRIPTION
Previously, it would report "multiple server files" if 0 were found.