### PR TITLE
Fix jinja2 template loader

### DIFF
--- a/wg_dashboard_backend/util.py
+++ b/wg_dashboard_backend/util.py
@@ -1,2 +1,4 @@
-from jinja2 import Environment, PackageLoader
-jinja_env = Environment(loader=PackageLoader(__name__, 'templates'))
+import os
+from jinja2 import Environment, FileSystemLoader
+templates_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
+jinja_env = Environment(loader=FileSystemLoader(templates_path))


### PR DESCRIPTION
We can only use the PackageLoader inside a package, which we don't have.

Maybe not the prettiest solution, but it fixes #102