### PR TITLE
Fix importing of IPv6 addresses

### DIFF
--- a/wg_dashboard_frontend/src/app/page/dashboard/add-server/add-server.component.ts
+++ b/wg_dashboard_frontend/src/app/page/dashboard/add-server/add-server.component.ts
@@ -11,6 +11,7 @@ import {forkJoin, from} from "rxjs";
 import {map, mergeMap} from "rxjs/operators";
 import {NotifierService} from "angular-notifier";
 import {MatCheckboxChange} from "@angular/material/checkbox";
+import {Address4, Address6} from 'ip-address'
 @Component({
   selector: 'app-add-server',
   templateUrl: './add-server.component.html',
@@ -174,8 +175,19 @@ export class AddServerComponent implements OnInit {
       return false;
     }
 
-    iFace.nodes["subnet"] = iFace.nodes["address"].split("/")[1];
-    iFace.nodes["address"] = iFace.nodes["address"].split("/")[0];
+    iFace.nodes["address"]
+    .split(",")
+    .map(x => x.trim())
+    .forEach(cidr => {
+      const [address, subnet] = cidr.split("/");
+      if (Address4.isValid(address)) {
+        iFace.nodes["address"] = address;
+        iFace.nodes["subnet"] = subnet;
+      } else if (Address6.isValid(address)) {
+        iFace.nodes["v6_address"] = address;
+        iFace.nodes["v6_subnet"] = subnet;
+      }
+    })
 
     iFace.nodes["peers"] = sPeers
       .map( x => x.nodes)

--- a/wg_dashboard_frontend/src/app/page/dashboard/add-server/add-server.component.ts
+++ b/wg_dashboard_frontend/src/app/page/dashboard/add-server/add-server.component.ts
@@ -193,7 +193,19 @@ export class AddServerComponent implements OnInit {
       .map( x => x.nodes)
       .map( x => {
       x.server_id = -1;
-      x.address = x.allowed_ips.split("/")[0];  // Allowed_ips in server is the address of the peer (Seen from server perspective)
+
+      x.allowed_ips // Allowed_ips in server is the address of the peer (Seen from server perspective)
+      .split(",")
+      .map(x => x.trim())
+      .forEach(cidr => {
+        const [address, subnet] = cidr.split("/");
+        if (Address4.isValid(address)) {
+          x.address = address;
+        } else if (Address6.isValid(address)) {
+          x.v6_address = address;
+        }
+      })
+
       x.allowed_ips = null;  // This should be retrieved from peer data config
       return x;
     })

--- a/wg_dashboard_frontend/src/app/validators/ip-address.validator.ts
+++ b/wg_dashboard_frontend/src/app/validators/ip-address.validator.ts
@@ -5,16 +5,10 @@ import {Address4, Address6} from 'ip-address'
 export class IPValidator {
 
   static isIPAddress(control: AbstractControl): ValidationErrors | null {
-
-    try {
-      new Address4(control.value)
-      return null
-    } catch (e) {}
-    try{
-      new Address6(control.value)
-      return null
-    } catch (e) {}
-    return { validIP: true };
+    if (Address4.isValid(control.value) || Address6.isValid(control.value))
+      return null;
+    else
+      return { validIP: true };
   }
 
 


### PR DESCRIPTION
The "address" field in a configuration file can be a comma-separated list of IPv4 and IPv6 addresses, e.g.:

```
Address = 10.0.100.1/24, fd86:ea04:1110::1/64
```