### PR TITLE
Added missing import

### DIFF
--- a/wg-manager-backend/db/user.py
+++ b/wg-manager-backend/db/user.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 from database import models
+from middleware import get_password_hash
 
 import schemas
 


### PR DESCRIPTION
When creation a user using db/user.py, the get_password_hash import is missing