### PR TITLE
[WIP] use pywireguard instead of calling wg and wg-quick

### DIFF
--- a/wg-manager-backend/requirements.txt
+++ b/wg-manager-backend/requirements.txt
@@ -20,3 +20,4 @@ qrcode[pil]
 alembic
 loguru
 ldap3==2.9
+pywireguard==0.1.3


### PR DESCRIPTION
Use wireguard C API directly (via pywireguard) instead  of generating configuration files and calling wg and wg-quick.

It will also stop requiring to have wg-tools installed on host.