### PR TITLE
Hotfix for being unable to disable IPv6 support

### DIFF
--- a/wg-manager-backend/database/models.py
+++ b/wg-manager-backend/database/models.py
@@ -35,7 +35,7 @@ class WGServer(Base):
     subnet = Column(sqlalchemy.Integer, nullable=False)
     address = Column(sqlalchemy.String, unique=True)
     v6_address = Column(sqlalchemy.String, unique=True)
-    v6_subnet = Column(sqlalchemy.Integer, nullable=False)
+    v6_subnet = Column(sqlalchemy.Integer)
     listen_port = Column(sqlalchemy.String, unique=True)
     private_key = Column(sqlalchemy.String)
     public_key = Column(sqlalchemy.String)


### PR DESCRIPTION
IPv6 Support is an optional feature, in that when you create an interface, you can disable IPv6 support with a checkbox. This greys out the ipv6 options, which means when the form is submitted on the front-end, it only hands IPv4 information to the back-end. This is a problem, as the database was created with the v6_subnet column set to `NOT NULL`

A more elegant fix would be to have the front-end submit dummy data for the IPv6 subnet, this way existing users would not be required to manually modify their database (as SQLite does not support altering tables to remove the `NOT NULL` property) to either recreate the table and all of its triggers/keys, or (and this is more reasonable) have the backend make a new database and then have the existing user manually import data from their old database.

(EDIT: Should note, however, that I've tested this fix and have found no issues with **EDITING** an existing configuration using this change. I've not tested if you can **CREATE** a new configuration with the change, however I believe it wouldn't make a difference.)

Unfortunately, I'm unfamiliar with Angular, however if I were a betting man I'd say you could probably insert something into the following spot to override the value submitted despite the field being disabled.

https://github.com/perara/wg-manager/blob/e70ba4bdc288318bc164fe696750a0c40ed1fac6/wg-manager-frontend/src/app/page/dashboard/add-server/add-server.component.ts#L84-L94